### PR TITLE
Needed to build with Xcode 13.2 (clang13.0).

### DIFF
--- a/src/macos/PreferencesPolicy.hh
+++ b/src/macos/PreferencesPolicy.hh
@@ -8,6 +8,7 @@
 
 #include <napi.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <optional>
 #include "../Policy.hh"
 
 using namespace Napi;


### PR DESCRIPTION
On my Mac running Xcode 13.2 on macOS 11.7.10, npm ci would fail installing policy-watcher until I added an include for optional.